### PR TITLE
Renamed 'OpenMP', 'Open.MP' to 'open.mp'

### DIFF
--- a/Applying Fundamentals.md
+++ b/Applying Fundamentals.md
@@ -66,7 +66,7 @@ In the above code you can see some new functions and callbacks which are explain
 #### public OnPlayerConnect (playerid)
 As in the last chapter, the OnPlayerConnect callback is called whenever a player connects to the server.
 #### public OnPlayerEnterCheckpoint (playerid)
-The OnPlayerEnterCheckpoint is called whenever a player enters a simple checkpoint. A checkpoint is a red colored circular area often seen in single-player missions. The function used to create a checkpoint for a player is SetPlayerCheckpoint () which takes in five arguments : (Add Open.MP Function Link Here)
+The OnPlayerEnterCheckpoint is called whenever a player enters a simple checkpoint. A checkpoint is a red colored circular area often seen in single-player missions. The function used to create a checkpoint for a player is SetPlayerCheckpoint () which takes in five arguments : (Add open.mp Function Link Here)
 ```c
 SetPlayerCheckpoint (playerid, Float: x, Float: y, Float: z, Float: z);
 
@@ -81,7 +81,7 @@ Float: z - The z-axis coordinates for the checkpoint.
 *Note: If we use this function twice in a row, the older checkpoint will be removed which shows that a player can have only one checkpoint visible / functional at a time.*
 
 #### public OnDialogResponse (playerid, dialogid, response, listitem, inputtext[])
-The OnDialogResponse callback is triggered when a player interacts with a dialog shown to them. Dialogs are a way to display information to the player and/or take input from the user. There are different types of dialogs namely simple text box, input fields or lists. The function to show a dialog to a player is ShowPlayerDialog : (Add Function Link Here, From Open.MP)
+The OnDialogResponse callback is triggered when a player interacts with a dialog shown to them. Dialogs are a way to display information to the player and/or take input from the user. There are different types of dialogs namely simple text box, input fields or lists. The function to show a dialog to a player is ShowPlayerDialog : (Add Function Link Here, From open.mp)
 ```c
 ShowPlayerDialog (playerid, dialogid, style, caption, info, button1, button2);
 

--- a/Fundamentals.md
+++ b/Fundamentals.md
@@ -6,17 +6,35 @@ Pawn is a modification of Small-C which is in-turn a subset language of the Orig
 
 The concept of ‘typed’ and ‘typeless’ languages will be explained in later sections.
 
-- [Comments](#comments)
-- [Symbols and Operators](#symbols-and-operators)
-- [String Formatting](#string-formatting)
-- [Variables](#variables)
-- [Constants](#constants)
-- [Conditionals](#conditionals)
-- [Loops](#loops)
-- [Functions](#functions)
-- [Enumerators](#enumerators)
-- [Preprocessor Directives](#preprocessor-directives)
-- [Compiler Warnings / Errors](#compiler-warnings)
+- [The Pawn Language | Fundamentals](#the-pawn-language--fundamentals)
+  - [Comments](#comments)
+        - [Code](#code)
+        - [Output:](#output)
+        - [Code](#code-1)
+        - [Output](#output-1)
+  - [Symbols and Operators](#symbols-and-operators)
+    - [Basic Symbols](#basic-symbols)
+      - [• Braces](#-braces)
+      - [• Parentheses](#-parentheses)
+      - [• Semi-colon](#-semi-colon)
+      - [• Single and Double Quotation Symbols](#-single-and-double-quotation-symbols)
+      - [• Revision](#-revision)
+    - [Operators](#operators)
+    - [String Formatting](#string-formatting)
+  - [Variables](#variables)
+        - [Examples:](#examples)
+  - [Constants](#constants)
+  - [Conditionals](#conditionals)
+        - [Code](#code-2)
+        - [Output](#output-2)
+  - [Loops](#loops)
+    - [‘For’ Loop](#for-loop)
+    - [While Loop](#while-loop)
+    - [Do…While Loop](#dowhile-loop)
+  - [Functions](#functions)
+  - [Enumerators](#enumerators)
+  - [Preprocessor Directives](#preprocessor-directives)
+  - [Compiler Warnings / Errors](#compiler-warnings--errors)
 
 
 
@@ -676,7 +694,7 @@ SetPlayerPos (playerid, Float: x, Float: y, Float: z);
 // Sets the player's position to some x, y, z coordinates. 
 // 'z' represents the vertical axis.
 ```
-A complete list of functions can be found on the Open.MP Wiki : https://www.open.mp/docs/scripting/functions
+A complete list of functions can be found on the open.mp Wiki : https://www.open.mp/docs/scripting/functions
 We can use functions creatively for the making of various features. Following is the code for a ‘One-shot Deagle Deathmatch’ where the player upon spawning will be given a Desert Eagle gun with 3 bullets and 10.0 health :
 ```c
 #include <a_samp>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # From-A-Little-Clucker-To-A-Spam-Machine
-A book about the PAWN Language (and SA-MP/OpenMP Development), written for absolute beginners.
+A book about the PAWN Language (and SA-MP/open.mp Development), written for absolute beginners.
 
 ### Contributors :
 - None


### PR DESCRIPTION
This pull request renames "OpenMP" and "Open.MP" to just "open.mp".